### PR TITLE
Marienstraße 23 is in Stuttgart Süd, not West

### DIFF
--- a/website/content/announcement-2016-04.md
+++ b/website/content/announcement-2016-04.md
@@ -15,7 +15,7 @@ Unser erstes Treffen ist am Donnerstag, den 21.4. in der Marienstrasse 23 bei ae
 
 ### Wo:
 
-Marienstrasse 23, Stuttgart-West, aexea (1. OG)
+Marienstrasse 23, Stuttgart-Süd, aexea (1. OG)
 
 ### Bitte meldet euch an unter:
 [https://www.letsmeet.click/c/machine-learning-user-group-stuttgart](https://www.letsmeet.click/c/machine-learning-user-group-stuttgart)

--- a/website/content/announcement-2016-06.md
+++ b/website/content/announcement-2016-06.md
@@ -18,7 +18,7 @@ Unser zweites Treffen ist am Dienstag, den 21.6. in der Marienstrasse 23 bei aex
 
 ### Wo:
 
-Marienstrasse 23, Stuttgart-West, aexea (1. OG)
+Marienstrasse 23, Stuttgart-Süd, aexea (1. OG)
 
 ### Bitte meldet euch an unter:
 [https://www.letsmeet.click/c/machine-learning-user-group-stuttgart](https://www.letsmeet.click/c/machine-learning-user-group-stuttgart)

--- a/website/content/announcement-2016-07.md
+++ b/website/content/announcement-2016-07.md
@@ -19,7 +19,7 @@ Unser drittes Treffen ist am Dienstag, den 19.7. in der Marienstrasse 23 bei aex
 
 ### Wo:
 
-Marienstrasse 23, Stuttgart-West, aexea (1. OG)
+Marienstrasse 23, Stuttgart-Süd, aexea (1. OG)
 
 ### Bitte meldet euch an unter:
 [https://www.letsmeet.click/c/machine-learning-user-group-stuttgart](https://www.letsmeet.click/c/machine-learning-user-group-stuttgart)

--- a/website/content/announcement-2016-09.md
+++ b/website/content/announcement-2016-09.md
@@ -17,7 +17,7 @@ Unser viertes Treffen ist am Dienstag, den 20.9. in der Marienstrasse 23 bei aex
 
 ### Wo:
 
-Marienstrasse 23, Stuttgart-West, aexea (1. OG)
+Marienstrasse 23, Stuttgart-Süd, aexea (1. OG)
 
 ### Bitte meldet euch an unter:
 [https://www.letsmeet.click/c/machine-learning-user-group-stuttgart](https://www.letsmeet.click/c/machine-learning-user-group-stuttgart)

--- a/website/content/announcement-2016-10.md
+++ b/website/content/announcement-2016-10.md
@@ -19,7 +19,7 @@ URL: http://www.5analytics.com/
 
 ### Wo:
 
-Marienstrasse 23, Stuttgart-West, aexea (1. OG)
+Marienstrasse 23, Stuttgart-Süd, aexea (1. OG)
 
 ### Bitte meldet euch an unter:
 [https://www.letsmeet.click/c/machine-learning-user-group-stuttgart](https://www.letsmeet.click/c/machine-learning-user-group-stuttgart)

--- a/website/content/announcement-2016-11.md
+++ b/website/content/announcement-2016-11.md
@@ -15,7 +15,7 @@ Unser sechstes Treffen ist am Dienstag, dem 15.11. in der Marienstrasse 23 bei a
 
 ### Wo:
 
-Marienstrasse 23, Stuttgart-West, aexea (1. OG)
+Marienstrasse 23, Stuttgart-Süd, aexea (1. OG)
 
 ### Bitte meldet euch an unter:
 [https://www.letsmeet.click/c/machine-learning-user-group-stuttgart](https://www.letsmeet.click/c/machine-learning-user-group-stuttgart)

--- a/website/content/announcement-2017-01.md
+++ b/website/content/announcement-2017-01.md
@@ -15,7 +15,7 @@ Unser siebtes Treffen ist am Dienstag, dem 17.01. in der Marienstrasse 23 bei ae
 
 ### Wo:
 
-Marienstrasse 23, Stuttgart-West, aexea (1. OG)
+Marienstrasse 23, Stuttgart-Süd, aexea (1. OG)
 
 ### Bitte meldet euch an unter:
 [https://www.letsmeet.click/c/machine-learning-user-group-stuttgart](https://www.letsmeet.click/c/machine-learning-user-group-stuttgart)

--- a/website/content/announcement-2017-02.md
+++ b/website/content/announcement-2017-02.md
@@ -15,7 +15,7 @@ Unser achtes Treffen ist am Dienstag, dem 21.2. in der Marienstrasse 23 bei aexe
 
 ### Wo:
 
-Marienstrasse 23, Stuttgart-West, aexea (1. OG)
+Marienstrasse 23, Stuttgart-Süd, aexea (1. OG)
 
 ### Bitte meldet euch an unter:
 [https://www.letsmeet.click/c/machine-learning-user-group-stuttgart](https://www.letsmeet.click/c/machine-learning-user-group-stuttgart)

--- a/website/content/announcement-2017-03.md
+++ b/website/content/announcement-2017-03.md
@@ -24,7 +24,7 @@ Inspirationen:
 
 ### Wo:
 
-Marienstrasse 23, Stuttgart-West, aexea (1. OG)
+Marienstrasse 23, Stuttgart-Süd, aexea (1. OG)
 
 ### Bitte meldet euch an unter:
 [https://www.letsmeet.click/c/machine-learning-user-group-stuttgart](https://www.letsmeet.click/c/machine-learning-user-group-stuttgart)

--- a/website/content/announcement-2017-04.md
+++ b/website/content/announcement-2017-04.md
@@ -22,7 +22,7 @@ Unser zehntes Treffen ist am Dienstag, dem 18.4. in der Marienstrasse 23 bei aex
 
 ### Wo:
 
-Marienstrasse 23, Stuttgart-West, aexea (1. OG)
+Marienstrasse 23, Stuttgart-Süd, aexea (1. OG)
 
 ### Bitte meldet euch an unter:
 [https://www.letsmeet.click/c/machine-learning-user-group-stuttgart](https://www.letsmeet.click/c/machine-learning-user-group-stuttgart)

--- a/website/content/announcement-2017-06.md
+++ b/website/content/announcement-2017-06.md
@@ -16,7 +16,7 @@ Unser elftes Treffen ist am Dienstag, dem 20.6. in der Marienstrasse 23 bei aexe
 
 ### Wo:
 
-Marienstrasse 23, Stuttgart-West, aexea (1. OG)
+Marienstrasse 23, Stuttgart-Süd, aexea (1. OG)
 
 ### Bitte meldet euch an unter:
 [https://www.letsmeet.click/c/machine-learning-user-group-stuttgart](https://www.letsmeet.click/c/machine-learning-user-group-stuttgart)

--- a/website/content/announcement-2017-09.md
+++ b/website/content/announcement-2017-09.md
@@ -21,7 +21,7 @@ Unser zwölftes Treffen ist am Dienstag, dem 19.9. in der Marienstrasse 23 bei a
 
 ### Wo:
 
-Marienstrasse 23, Stuttgart-West, aexea (1. OG)
+Marienstrasse 23, Stuttgart-Süd, aexea (1. OG)
 
 ### Bitte meldet euch an unter:
 [https://www.letsmeet.click/c/machine-learning-user-group-stuttgart](https://www.letsmeet.click/c/machine-learning-user-group-stuttgart)

--- a/website/content/announcement-2017-10.md
+++ b/website/content/announcement-2017-10.md
@@ -18,7 +18,7 @@ Unser dreizehntes Treffen ist am Dienstag, dem 17.10. in der Marienstrasse 23 be
 
 ### Wo:
 
-Marienstrasse 23, Stuttgart-West, aexea (1. OG)
+Marienstrasse 23, Stuttgart-Süd, aexea (1. OG)
 
 ### Bitte meldet euch an unter:
 [https://www.letsmeet.click/c/machine-learning-user-group-stuttgart](https://www.letsmeet.click/c/machine-learning-user-group-stuttgart)

--- a/website/content/announcement-2017-11.md
+++ b/website/content/announcement-2017-11.md
@@ -20,7 +20,7 @@ Unser vierzehntes Treffen ist am Dienstag, dem 21.11. in der Marienstrasse 23 be
 
 ### Wo:
 
-Marienstrasse 23, Stuttgart-West, aexea (1. OG)
+Marienstrasse 23, Stuttgart-Süd, aexea (1. OG)
 
 ### Bitte meldet euch an unter:
 [https://www.letsmeet.click/c/machine-learning-user-group-stuttgart](https://www.letsmeet.click/c/machine-learning-user-group-stuttgart)

--- a/website/content/announcement-2018-01.md
+++ b/website/content/announcement-2018-01.md
@@ -25,7 +25,7 @@ Language: German only.
 
 ### Wo:
 
-Marienstrasse 23, Stuttgart-West, AX Semantics (aexea) (1. OG)
+Marienstrasse 23, Stuttgart-Süd, AX Semantics (aexea) (1. OG)
 
 ### Bitte meldet euch an unter:
 [https://www.meetup.com/Machine-Learning-UserGroup-Stuttgart](https://www.meetup.com/Machine-Learning-UserGroup-Stuttgart)

--- a/website/content/announcement-2018-02.md
+++ b/website/content/announcement-2018-02.md
@@ -22,7 +22,7 @@ Wir suchen noch weitere Vorträge.
 
 ### Wo:
 
-Marienstrasse 23, Stuttgart-West, AX Semantics (aexea) (1. OG)
+Marienstrasse 23, Stuttgart-Süd, AX Semantics (aexea) (1. OG)
 
 ### Bitte meldet euch an unter:
 [https://www.meetup.com/Machine-Learning-UserGroup-Stuttgart](https://www.meetup.com/Machine-Learning-UserGroup-Stuttgart)

--- a/website/content/announcement-2018-03.md
+++ b/website/content/announcement-2018-03.md
@@ -20,7 +20,7 @@ Language: German only.
 
 ### Wo:
 
-Marienstrasse 23, Stuttgart-West, AX Semantics (aexea) (1. OG)
+Marienstrasse 23, Stuttgart-Süd, AX Semantics (aexea) (1. OG)
 
 ### Bitte meldet euch an unter:
 [https://www.meetup.com/Machine-Learning-UserGroup-Stuttgart](https://www.meetup.com/Machine-Learning-UserGroup-Stuttgart)

--- a/website/content/announcement-2018-04.md
+++ b/website/content/announcement-2018-04.md
@@ -17,7 +17,7 @@ Language: German only.
 
 ### Wo:
 
-Marienstrasse 23, Stuttgart-West, AX Semantics (1. OG)
+Marienstrasse 23, Stuttgart-Süd, AX Semantics (1. OG)
 
 ### Bitte meldet euch an unter:
 [https://www.meetup.com/Machine-Learning-UserGroup-Stuttgart](https://www.meetup.com/Machine-Learning-UserGroup-Stuttgart)

--- a/website/content/announcement-2018-05.md
+++ b/website/content/announcement-2018-05.md
@@ -25,7 +25,7 @@ Stellt eure Projekte/Lösungen/Ideen vor.
 
 ### Wo:
 
-Marienstrasse 23, Stuttgart-West, AX Semantics (1. OG)
+Marienstrasse 23, Stuttgart-Süd, AX Semantics (1. OG)
 
 ### Bitte meldet euch an unter:
 [https://www.meetup.com/Machine-Learning-UserGroup-Stuttgart](https://www.meetup.com/Machine-Learning-UserGroup-Stuttgart)

--- a/website/content/announcement-2018-06.md
+++ b/website/content/announcement-2018-06.md
@@ -22,7 +22,7 @@ Stellt eure Projekte/Lösungen/Ideen vor.
 
 ### Wo:
 
-Marienstrasse 23, Stuttgart-West, AX Semantics (1. OG)
+Marienstrasse 23, Stuttgart-Süd, AX Semantics (1. OG)
 
 ### Bitte meldet euch an unter:
 [https://www.meetup.com/Machine-Learning-UserGroup-Stuttgart](https://www.meetup.com/Machine-Learning-UserGroup-Stuttgart)

--- a/website/content/announcement-2018-09.md
+++ b/website/content/announcement-2018-09.md
@@ -29,7 +29,7 @@ Stellt eure Projekte/Lösungen/Ideen vor.
 
 ### Wo:
 
-Marienstrasse 23, Stuttgart-West, AX Semantics (1. OG)
+Marienstrasse 23, Stuttgart-Süd, AX Semantics (1. OG)
 
 ### Bitte meldet euch an unter:
 [https://www.meetup.com/Machine-Learning-UserGroup-Stuttgart](https://www.meetup.com/Machine-Learning-UserGroup-Stuttgart)

--- a/website/content/announcement-2018-10.md
+++ b/website/content/announcement-2018-10.md
@@ -18,7 +18,7 @@ Stellt eure Projekte/Lösungen/Ideen vor.
 
 ### Wo:
 
-Marienstrasse 23, Stuttgart-West, AX Semantics (1. OG)
+Marienstrasse 23, Stuttgart-Süd, AX Semantics (1. OG)
 
 ### Bitte meldet euch an unter:
 [https://www.meetup.com/Machine-Learning-UserGroup-Stuttgart](https://www.meetup.com/Machine-Learning-UserGroup-Stuttgart)


### PR DESCRIPTION
See https://gis6.stuttgart.de/maps/index.html?karte=leben&embedded=false#basemap=0&scale=1128&centerX=1020896.4024171393&centerY=6236169.611391166